### PR TITLE
特定の outside collaborator を除外する機能を追加

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,10 @@
         },
         "IGNORE_USERS": {
             "description": "Ignore users for TFA checker (ex. user1,user2)"
+        },
+        "IGNORE_COLLABORATORS": {
+            "description": "Ignore outside collaborators for permission checker (ex. user1,user2)",
+            "required": false
         }
     },
     "addons": [

--- a/lib/github_org_permission_checker.rb
+++ b/lib/github_org_permission_checker.rb
@@ -6,12 +6,14 @@ class GithubOrgPermissionChecker
   # @param org_name [String] GitHub Organization
   # @param access_token [String] GitHub Access Token
   # @param teams_permission [String] Teams permission
+  # @param ignore_collaborators [String] Ignore outside collaborators for checking
   # @param skip_days [String] Skip days for checking
   # @param notifier [#post] the notifier object to post
-  def initialize(org_name:, access_token:, teams_permission:, skip_days:, notifier:)
+  def initialize(org_name:, access_token:, teams_permission:, ignore_collaborators:, skip_days:, notifier:)
     @org_name = org_name
     @access_token = access_token
     @raw_teams_permission = teams_permission
+    @raw_ignore_collaborators = ignore_collaborators
     @skip_days = skip_days
     @notifier = notifier
   end
@@ -52,7 +54,7 @@ class GithubOrgPermissionChecker
 
   private
 
-  attr_reader :org_name, :access_token, :raw_teams_permission, :skip_days, :notifier
+  attr_reader :org_name, :access_token, :raw_teams_permission, :raw_ignore_collaborators, :skip_days, :notifier
 
   def skip?
     skip_days &&
@@ -78,7 +80,7 @@ class GithubOrgPermissionChecker
       end
     end
 
-    collaborators(repo).empty?
+    collaborators(repo).reject {|collaborator| ignore_collaborator?(collaborator)}.empty?
   end
 
   # PowerUsers=admin,Users=push
@@ -103,6 +105,23 @@ class GithubOrgPermissionChecker
 
   def collaborators(repo)
     client.collaborators(repo[:full_name], affiliation: 'outside')
+  end
+
+  # 無視するコラボレーターかを返す
+  #
+  # @param collaborator [Sawyer::Resource]
+  # @return [Boolean]
+  def ignore_collaborator?(collaborator)
+    ignore_collaborators.include?(collaborator[:login])
+  end
+
+  # user1,user2
+  # ↓
+  # ["user1", "user2"]
+  #
+  # @return [Array<String>]
+  def ignore_collaborators
+    @ignore_collaborators ||= (raw_ignore_collaborators || '').split(',')
   end
 
   def client

--- a/permission.rb
+++ b/permission.rb
@@ -14,6 +14,7 @@ GithubOrgPermissionChecker.new(
   org_name:         ENV['GITHUB_ORGANIZATION'],
   access_token:     ENV['GITHUB_ACCESS_TOKEN'],
   teams_permission: ENV['TEAMS_PERMISSION'],
+  ignore_collaborators: ENV['IGNORE_COLLABORATORS'],
   skip_days:        ENV['SKIP_DAYS'],
   notifier:         notifier
 ).execute


### PR DESCRIPTION
## 概要

permission チェッカーに、特定の outside collaborator を通知対象から除外する `IGNORE_COLLABORATORS` 環境変数を追加した。

## 背景

outside collaborator を一定期間リポジトリに追加したいが、現状だと outside collaborator が 1 人でも居るとそのリポジトリが NG として Slack に通知されてしまうため特定のユーザーのみ無視したい。
指定されていない outside collaborator は引き続き NG として検出する。

## 変更内容

- `GithubOrgPermissionChecker` に `ignore_collaborators` 引数を追加し、指定ユーザーを outside collaborator の空チェックから除外
  - TFA チェッカーの既存の `IGNORE_USERS` パターンを踏襲
  - 環境変数未設定（nil）でも従来どおり動作する
- `permission.rb` で `ENV['IGNORE_COLLABORATORS']` を渡すように変更
- `app.json` に `IGNORE_COLLABORATORS` を宣言（`required: false`）

## 使い方

GitHub のログイン名（`https://github.com/<この部分>`）をカンマ区切りで指定する。

```sh
# 追加 
heroku config:set IGNORE_COLLABORATORS=candidate1,candidate2 --app <App Name>

# 削除
heroku config:unset IGNORE_COLLABORATORS --app <App Name>
```

## 動作確認

- `ruby -c` による構文チェック
- Octokit クライアントをスタブして 4 ケースを検証
  - 環境変数 nil + collaborator なし → 通知なし
  - 環境変数 nil + collaborator あり → 通知あり（従来動作の維持）
  - 除外指定ユーザーのみ → 通知なし
  - 除外指定ユーザー + 未指定ユーザー → 通知あり

